### PR TITLE
Fixing path check on project creation page

### DIFF
--- a/ExternalModule.php
+++ b/ExternalModule.php
@@ -30,7 +30,7 @@ class ExternalModule extends AbstractExternalModule {
      */
     function redcap_every_page_top($project_id) {
         // The ownership fieldset is only placed on create and edit project forms.
-        if ((strpos(PAGE, 'redcap/index.php') === 0 && !empty($_GET['action']) && $_GET['action'] == 'create') || PAGE == 'ProjectSetup/index.php') {
+        if ((strpos(PAGE, substr(APP_PATH_WEBROOT_PARENT, 1) . 'index.php') === 0 && !empty($_GET['action']) && $_GET['action'] == 'create') || PAGE == 'ProjectSetup/index.php') {
             $this->buildOwnershipFieldset($project_id);
         }
     }


### PR DESCRIPTION
Review steps:
- [ ] In a local redcap app (let's say it's located at `/var/www/redcap`) containing this module enabled globally, make sure the ownership form fields appear at project creation page
- [ ] Temporarily move your redcap docroot to another location, e.g. `/var/www/redcap2`
- [ ] Repeat step 1