### PR TITLE
Handling copy project case

### DIFF
--- a/ExternalModule.php
+++ b/ExternalModule.php
@@ -29,10 +29,23 @@ class ExternalModule extends AbstractExternalModule {
      * @inheritdoc
      */
     function redcap_every_page_top($project_id) {
-        // The ownership fieldset is only placed on create and edit project forms.
-        if ((strpos(PAGE, substr(APP_PATH_WEBROOT_PARENT, 1) . 'index.php') === 0 && !empty($_GET['action']) && $_GET['action'] == 'create') || PAGE == 'ProjectSetup/index.php') {
-            $this->buildOwnershipFieldset($project_id);
+        if (PAGE == 'ProjectSetup/index.php') {
+            // Edit project form.
+            $context = 'edit';
         }
+        elseif (PAGE == 'ProjectGeneral/copy_project_form.php') {
+            // Copy project form.
+            $context = 'copy';
+        }
+        elseif (strpos(PAGE, substr(APP_PATH_WEBROOT_PARENT, 1) . 'index.php') === 0 && !empty($_GET['action']) && $_GET['action'] == 'create') {
+            // Create project form.
+            $context = 'create';
+        }
+        else {
+            return;
+        }
+
+        $this->buildOwnershipFieldset($context, $project_id);
     }
 
     /**
@@ -79,7 +92,7 @@ class ExternalModule extends AbstractExternalModule {
     /**
      * Builds ownership fieldset.
      */
-    protected function buildOwnershipFieldset($project_id = null) {
+    protected function buildOwnershipFieldset($context, $project_id = null) {
         /**
          * The method call below is a workaround to be used until the following
          * pull request is merged and released.
@@ -153,11 +166,16 @@ class ExternalModule extends AbstractExternalModule {
 
         // Passing fieldset content to JS.
         $settings = array(
-            'projectId' => $project_id,
+            'context' => $context,
             'userId' => USERID,
             'userInfoAjaxPath' => $this->getUrl('plugins/user_info_ajax.php'),
             'fieldsetContents' => RCView::tr(array('id' => 'po-tr', 'valign' => 'top'), $output),
         );
+
+        if ($context == 'copy') {
+            global $lang;
+            $settings['copyTitleErrorMsg'] = $lang['copy_project_11'];
+        }
 
         $this->setJsSettings($settings);
 

--- a/js/owner-fieldset.js
+++ b/js/owner-fieldset.js
@@ -82,27 +82,34 @@ $(document).ready(function() {
 
     // Overriding submit callbacks for each case: create and edit project
     // settings.
-    if (projectOwnership.projectId) {
-        var saveCallback = function() {
-            $('#editprojectform').submit();
-        };
+    switch (projectOwnership.context) {
+        case 'copy':
+        case 'create':
+            var saveCallback = function() {
+                showProgress(1);
+                document.createdb.submit();
+            };
 
-        $('#edit_project').on('dialogopen', function() {
-            var buttons = $(this).dialog('option', 'buttons');
+            // Overriding submit button's click callback.
+            var $submit = $('form table tr').last().find('td button').first();
+            $submit[0].onclick = projectOwnershipSubmit;
 
-            // Overriding dialog's save button.
-            buttons.Save = projectOwnershipSubmit;
-            $(this).dialog('option', 'buttons', buttons);
-        });
-    }
-    else {
-        var saveCallback = function() {
-            document.createdb.submit();
-        };
+            break;
 
-        // Overriding submit button's click callback.
-        var $submit = $('form table tr').last().find('td button').first();
-        $submit[0].onclick = projectOwnershipSubmit;
+        case 'edit':
+            var saveCallback = function() {
+                $('#editprojectform').submit();
+            };
+
+            $('#edit_project').on('dialogopen', function() {
+                var buttons = $(this).dialog('option', 'buttons');
+
+                // Overriding dialog's save button.
+                buttons.Save = projectOwnershipSubmit;
+                $(this).dialog('option', 'buttons', buttons);
+            });
+
+            break;
     }
 
     // The new submit callback, that runs extra validation checks for project
@@ -110,6 +117,13 @@ $(document).ready(function() {
     function projectOwnershipSubmit() {
         if (!setFieldsCreateFormChk()) {
             return false;
+        }
+
+        if (projectOwnership.context === 'copy') {
+            if ($('#currenttitle').val() === $('#app_title').val()) {
+                simpleDialog(projectOwnership.copyTitleErrorMsg);
+                return false;
+            }
         }
 
         var userId = $username.val();


### PR DESCRIPTION
Fixes issue #8.

Review steps:
- [ ] Go to project copy page (click on "Copy project" button under "Other functionality" tab) and make sure you see the ownership fields placed on the form
- [ ] Make sure you are not allowed to proceed until ownership fields are filled out
- [ ] Submit form and make sure it goes smoothly
- [ ] On your new project, click on "Modify project title, purpose, etc" button and make sure the information you saved has persisted
- [ ] Look for regressions on project create and edit cases