### PR TITLE
Enforcing module to be enabled for all projects

### DIFF
--- a/ExternalModule.php
+++ b/ExternalModule.php
@@ -29,6 +29,17 @@ class ExternalModule extends AbstractExternalModule {
      * @inheritdoc
      */
     function redcap_every_page_top($project_id) {
+        if (strpos(PAGE, 'ExternalModules/manager/control_center.php') !== false) {
+            // Making sure the module is enabled for all projects.
+            // TODO: move it to redcap_module_system_enable as soon as this hook
+            // is released on REDCap.
+            $this->setSystemSetting(ExternalModules::KEY_ENABLED, true);
+            $this->includeJs('js/config.js');
+            $this->setJsSettings(array('modulePrefix' => $this->PREFIX));
+
+            return;
+        }
+
         if (PAGE == 'ProjectSetup/index.php') {
             // Edit project form.
             $context = 'edit';
@@ -80,13 +91,8 @@ class ExternalModule extends AbstractExternalModule {
         // TODO: remove it if and when this error handling becomes configurable.
         return;
 
-        $q = $this->query('SHOW TABLES LIKE "redcap_project_ownership"');
-        if (!db_num_rows($q)) {
-            return;
-        }
-
         // Removes project onwership table.
-        $this->query('DROP table redcap_project_ownership');
+        $this->query('DROP TABLE IF EXISTS redcap_project_ownership');
     }
 
     /**

--- a/js/config.js
+++ b/js/config.js
@@ -1,0 +1,22 @@
+$(document).ready(function() {
+    $modal = $('#external-modules-configure-modal');
+    $modal.on('show.bs.modal', function() {
+        // Making sure we are overriding this modules's modal only.
+        if ($modal.data('module') !== projectOwnership.modulePrefix) {
+            return;
+        }
+
+        if (typeof ExternalModules.Settings.prototype.configureSettingsOld === 'undefined') {
+            ExternalModules.Settings.prototype.configureSettingsOld = ExternalModules.Settings.prototype.configureSettings;
+        }
+
+        ExternalModules.Settings.prototype.configureSettings = function() {
+            ExternalModules.Settings.prototype.configureSettingsOld();
+
+            // Making sure we are overriding this modules's modal only.
+            if ($modal.data('module') === projectOwnership.modulePrefix) {
+                $modal.find('tr[field="enabled"] input').attr('disabled', 'disabled').attr('title', 'This module needs to be enabled for all projects.');
+            }
+        };
+    });
+});


### PR DESCRIPTION
Review steps:
- [x] Before updating your code, if you have an existing Project Ownership module enabled, make sure it is not enabled for all projects, and then disable it
- [x] Update the module code and enable the module on Control Center
- [x] Make sure you see "Enabled for All Projects" flag
- [x] Open config form and make sure you are not able to change the flag value