### PR TITLE
Only add billable and sequestered types if enable_uf_features is selected

### DIFF
--- a/ExternalModule.php
+++ b/ExternalModule.php
@@ -87,7 +87,7 @@ class ExternalModule extends AbstractExternalModule {
                     'name' => 'Billable',
                     'type' => 'boolean'
                 ];
-                $types['project_ownership']['properies']['sequestered'] = [
+                $types['project_ownership']['properties']['sequestered'] = [
                     'name' => 'Sequestered',
                     'type' => 'boolean',
                 ];

--- a/ExternalModule.php
+++ b/ExternalModule.php
@@ -79,16 +79,19 @@ class ExternalModule extends AbstractExternalModule {
                     'name' => 'Owner last name',
                     'type' => 'text',
                 ],
-                'billable' => [
-                    'name' => 'Billable',
-                    'type' => 'boolean',
-                ],
-                'sequestered' => [
-                    'name' => 'Sequestered',
-                    'type' => 'boolean',
-                ],
             ]
         ];
+
+        if ($this->getSystemSetting('enable_uf_features')) {
+               $types['project_ownership']['properties']['billable'] = [
+                    'name' => 'Billable',
+                    'type' => 'boolean'
+                ];
+                $types['project_ownership']['properies']['sequestered'] = [
+                    'name' => 'Sequestered',
+                    'type' => 'boolean',
+                ];
+            }
 
         return $types;
     }


### PR DESCRIPTION
Closes #54

Without this change, anyone who upgraded from <2.1.0 may have been unable to save new project owners at all if they did not run the SQL upgrade manually.

To test:

In a docker container:

If you already have RCPO installed and populated:
1. drop your existing `redcap_entity_project_ownership` table if one is populated
1. disable `redcap_entity_project_ownership`

After cleaning up any extant RCPO data
1. `git checkout 2.0.3`
2. activate RCPO
3. add a ownership data to a new or existing project
4. `cp -r` your `project_ownership` repo to a new directory, be sure to change the version
5. `cd` in to the new `project_ownership` directory
6. `git checkout develop` or `git checkout 2.1.0`
7. upgrade RCPO to your new version
8. attempt to add project ownership data to a different project than the project in step 3
9. observe the results on any project ownership plugin page